### PR TITLE
feat: add ability to set node.attr fields on each nodeSet

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "5.0.6"
+version: "5.1.0"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.es.yaml
+++ b/charts/lsdmop/templates/elastic.es.yaml
@@ -71,16 +71,9 @@ spec:
         #path.repo: /usr/share/elasticsearch/snapshots
         node.roles:
           {{ $nodeSet.roles | toYaml | indent 10 | trim }}
-{{- if or 
-   (has "data" $nodeSet.roles) 
-   (has "data_hot" $nodeSet.roles) 
-   (has "data_warm" $nodeSet.roles) 
-   (has "data_cold" $nodeSet.roles)  
-   (has "data_frozen" $nodeSet.roles) 
-   (has "data_content" $nodeSet.roles)
-}}
-        node.attr.data: {{ $name }}
-{{- end }}
+        {{- range $key, $val := $nodeSet.node_attributes }}
+        node.attr.{{ $key }}: {{ $val }}
+        {{- end }}
         http.max_content_length: 100mb
         http.compression: true
         transport.compress: true

--- a/charts/lsdmop/values.yaml
+++ b/charts/lsdmop/values.yaml
@@ -64,55 +64,60 @@ lsdmop:
     serviceAccount:
       annotations: {}    
     nodeSets: {}
-      # data-hot: 
-      #   count: 3
-      #   resources:
-      #     requests:
-      #       cpu: 1500m
-      #       memory: 30
-      #     limits:
-      #       cpu: 4000m
-      #       memory: 30
-      #   tolerations:
-      #   - effect: NoSchedule
-      #     key: dedicated
-      #     operator: Equal
-      #     value: elastic-hot
-      #   storagesize: 560Gi
-      #   storageClassName: ebs-gp3
-      #   nodeSelector: {}
-      #   roles: ["master", "data_hot", "transform", "remote_cluster_client", "ingest"]
-      # warm: 
-      #   count: 2
-      #   resources:
-      #     requests:
-      #       cpu: 1500m
-      #       memory: 30
-      #     limits:
-      #       cpu: 4000m
-      #       memory: 30
-      #   tolerations:
-      #   - effect: NoSchedule
-      #     key: dedicated
-      #     operator: Equal
-      #     value: elastic-warm
-      #   storagesize: 2760Gi
-      #   storageClassName: ebs-gp3
-      #   nodeSelector: {}
-      #   roles: ["master", "data_warm", "transform", "remote_cluster_client", "ingest"]
-      # ml: 
-      #   count: 2
-      #   resources:
-      #     requests:
-      #       cpu: 500m
-      #       memory: 16
-      #     limits:
-      #       cpu: 4000m
-      #       memory: 16
-      #   tolerations: []
-      #   storagesize: 1Gi
-      #   storageClassName: ebs-gp3
-      #   roles: ["ml"]
+#       data-hot:
+#         count: 3
+#         node_attributes:
+#           data: hot
+#         resources:
+#           requests:
+#             cpu: 1500m
+#             memory: 30
+#           limits:
+#             cpu: 4000m
+#             memory: 30
+#         tolerations:
+#         - effect: NoSchedule
+#           key: dedicated
+#           operator: Equal
+#           value: elastic-hot
+#         storagesize: 560Gi
+#         storageClassName: ebs-gp3
+#         nodeSelector: {}
+#         roles: ["master", "data_hot", "transform", "remote_cluster_client", "ingest"]
+#       warm:
+#         count: 2
+#         node_attributes:
+#           data: warm
+#           foo: bar
+#         resources:
+#           requests:
+#             cpu: 1500m
+#             memory: 30
+#           limits:
+#             cpu: 4000m
+#             memory: 30
+#         tolerations:
+#         - effect: NoSchedule
+#           key: dedicated
+#           operator: Equal
+#           value: elastic-warm
+#         storagesize: 2760Gi
+#         storageClassName: ebs-gp3
+#         nodeSelector: {}
+#         roles: ["master", "data_warm", "transform", "remote_cluster_client", "ingest"]
+#       ml:
+#         count: 2
+#         resources:
+#           requests:
+#             cpu: 500m
+#             memory: 16
+#           limits:
+#             cpu: 4000m
+#             memory: 16
+#         tolerations: []
+#         storagesize: 1Gi
+#         storageClassName: ebs-gp3
+#         roles: ["ml"]
     hostAliases: []
       # - hostnames:
       #     - ad.lsdopen.io


### PR DESCRIPTION
Allows a consumer to add the following to a node set which sets `node.attr.{key}: value` in each node set:

```yaml
node_attributes:
  data: hot
```