### PR TITLE
fix: move to dedicated ingress and have general es service back

### DIFF
--- a/.idea/material_theme_project_new.xml
+++ b/.idea/material_theme_project_new.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MaterialThemeProjectNewConfig">
+    <option name="metadata">
+      <MTProjectMetadataState>
+        <option name="userId" value="-3c43676d:1921dd8ce5a:-6e78" />
+      </MTProjectMetadataState>
+    </option>
+  </component>
+</project>

--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "5.1.1"
+version: "5.1.2"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.es.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.es.ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     app: elasticsearch
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"    
-  name: lsdmop-elasticsearch
+  name: {{ .Release.Name }}-elasticsearch
   namespace: {{ .Release.Namespace }}
 spec:
   ingressClassName: {{ .Values.lsdmop.elastic.ingress.className }}
@@ -26,7 +26,7 @@ spec:
       paths:
       - backend:
           service:
-             name: lsdmop-es-http
+             name: {{ .Release.Name }}-elasticsearch-ingress
              port: 
                number: 9200
         path: /

--- a/charts/lsdmop/templates/elastic.es.services.yaml
+++ b/charts/lsdmop/templates/elastic.es.services.yaml
@@ -35,3 +35,19 @@ spec:
   - name: https
     port: 9200
     targetPort: 9200
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: elasticsearch
+  name: {{ .Release.Name }}-elasticsearch-ingress
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    elasticsearch.k8s.elastic.co/cluster-name: {{ .Release.Name }}
+    elasticsearch.k8s.elastic.co/node-ingest: "true"
+  ports:
+    - name: https
+      port: 9200
+      targetPort: 9200

--- a/charts/lsdmop/templates/elastic.es.yaml
+++ b/charts/lsdmop/templates/elastic.es.yaml
@@ -50,7 +50,6 @@ spec:
         selector:
           common.k8s.elastic.co/type: elasticsearch
           elasticsearch.k8s.elastic.co/cluster-name: {{ .Release.Name }}
-          elasticsearch.k8s.elastic.co/node-ingest: "true"
     tls:
       certificate: {}
   transport:


### PR DESCRIPTION
I found a bug moving to dedicated masters. It seems like everything is trying to communicate over the general es service. Because I had set it to only work on ingest, it caused issues and nothing would start other then the dedicated masters.

This sets up a new service for ingest and the ingress points to that.