### PR TITLE
feat: add support for topology spread support

### DIFF
--- a/charts/lsdmop-connector/.helmignore
+++ b/charts/lsdmop-connector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lsdmop-connector/Chart.yaml
+++ b/charts/lsdmop-connector/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: lsdmop-connector
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/lsdmop-connector/templates/_helpers.tpl
+++ b/charts/lsdmop-connector/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lsdmop-connector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lsdmop-connector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" $name .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lsdmop-connector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lsdmop-connector.labels" -}}
+helm.sh/chart: {{ include "lsdmop-connector.chart" . }}
+{{ include "lsdmop-connector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lsdmop-connector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lsdmop-connector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lsdmop-connector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lsdmop-connector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/lsdmop-connector/templates/configmap.yaml
+++ b/charts/lsdmop-connector/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lsdmop-connector.fullname" . }}-config
+  labels:
+    {{- include "lsdmop-connector.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+    {{ .Values.config | indent 4 | trim }}

--- a/charts/lsdmop-connector/templates/deployment.yaml
+++ b/charts/lsdmop-connector/templates/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lsdmop-connector.fullname" . }}
+  labels:
+    {{- include "lsdmop-connector.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lsdmop-connector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lsdmop-connector.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          command:
+            - /app/bin/elastic-ingest
+            - -c
+            - /config/config.yaml
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "lsdmop-connector.fullname" . }}-config
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lsdmop-connector/values.yaml
+++ b/charts/lsdmop-connector/values.yaml
@@ -1,0 +1,80 @@
+# Default values for lsdmop-connector.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: docker.elastic.co/enterprise-search/elastic-connectors
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "8.15.0.0"
+
+# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+#livenessProbe:
+#  httpGet:
+#    path: /
+#    port: http
+#readinessProbe:
+#  httpGet:
+#    path: /
+#    port: http
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+config: ""

--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.0.5"
+version: "6.1.0"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.es.yaml
+++ b/charts/lsdmop/templates/elastic.es.yaml
@@ -4,34 +4,8 @@ kind: Elasticsearch
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
-{{- if .Values.elastic.autoscaling.enabled }}
   annotations:
-    elasticsearch.alpha.elastic.co/autoscaling-spec: |-
-      {
-          "pollingPeriod": "20s",
-          "policies": [{
-            "name": "hot-data",
-            "roles": ["master", "data_hot", "data", "transform", "remote_cluster_client", "ingest"],
-            "resources": {
-                "nodeCount": { "min": {{ .Values.elastic.cluster.hot.count }}, "max": {{ .Values.elastic.cluster.hot.maxcount }} }
-            }
-          },
-          {
-            "name": "warm-data",
-            "roles": ["master", "data_warm", "data", "data_content", "transform", "remote_cluster_client", "ingest"],
-            "resources": {
-                "nodeCount": { "min": {{ .Values.elastic.cluster.warm.count }}, "max": {{ .Values.elastic.cluster.warm.maxcount }} }
-            }
-          },
-          {
-            "name": "ml",
-            "roles": ["ml"],
-            "resources": {
-                "nodeCount": { "min": {{ .Values.elastic.cluster.ml.count }}, "max": {{ .Values.elastic.cluster.ml.maxcount }} }
-            }
-          }]
-      }
-{{- end}}    
+    {{ .Values.elastic.annotations | toYaml | indent 4 | trim }}
 spec:
   version: "{{ .Values.elastic.version }}"
   podDisruptionBudget:
@@ -48,6 +22,7 @@ spec:
         selector:
           common.k8s.elastic.co/type: elasticsearch
           elasticsearch.k8s.elastic.co/cluster-name: {{ .Release.Name }}
+          elasticsearch.k8s.elastic.co/node-ingress: "true"
     tls:
       certificate: {}
   transport:
@@ -57,13 +32,13 @@ spec:
         selector:
           common.k8s.elastic.co/type: elasticsearch
           elasticsearch.k8s.elastic.co/cluster-name: {{ .Release.Name }}
-          elasticsearch.k8s.elastic.co/node-data: "true"
     tls:
       certificate: { }
       certificateAuthorities: { }
   nodeSets:
 {{- range $name, $nodeSet := .Values.elastic.nodeSets }}
     - config:
+        cluster.routing.allocation.awareness.attributes: {{ $nodeSet.allocation_awareness | default "k8s_node_name" }}
         node.store.allow_mmap: false
         #path.repo: /usr/share/elasticsearch/snapshots
         {{- if not (empty $nodeSet.roles) }}
@@ -98,6 +73,33 @@ spec:
           labels:
             scrape: es
         spec:
+          affinity: {}
+          topologySpreadConstraints:
+          - labelSelector:
+              matchLabels:
+                elasticsearch.k8s.elastic.co/cluster-name: {{ .Release.Name }}
+            maxSkew: 1
+            minDomains: {{ $nodeSet.count }}
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: DoNotSchedule
+{{- if $nodeSet.enableZoneTopologySpread }}
+          - labelSelector:
+              matchLabels:
+                elasticsearch.k8s.elastic.co/cluster-name: {{ .Release.Name }}
+                elasticsearch.k8s.elastic.co/statefulset-name: lsdmop-es-{{ $name }}
+            maxSkew: 1
+            minDomains: 3
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: DoNotSchedule                        
+{{- end }}
+          #topologySpreadConstraints:
+          #  - maxSkew: 1
+          #    topologyKey: topology.kubernetes.io/zone
+          #    whenUnsatisfiable: DoNotSchedule
+          #    labelSelector:
+          #      matchLabels:
+          #        elasticsearch.k8s.elastic.co/cluster-name: elasticsearch-sample
+          #        elasticsearch.k8s.elastic.co/statefulset-name: elasticsearch-sample-es-default
           serviceAccountName: {{ $.Release.Name }}-elastic
           serviceAccount: {{ $.Release.Name }}-elastic
           automountServiceAccountToken: true

--- a/charts/lsdmop/values.yaml
+++ b/charts/lsdmop/values.yaml
@@ -3,6 +3,7 @@ curl:
 
 elastic:
   enabled: true
+  annotations: {}
   license:
     enabled: false
     key: ""


### PR DESCRIPTION
This solves two things:

- Allow for setting annotations on elastic resources
- Allow for enabling zone topology spread constraints
- Support to extend the shard allocation