### PR TITLE
fix: remove toleration allowing fleet server to be placed on data nodes

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.2.3"
+version: "6.2.4"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.fleet.yaml
+++ b/charts/lsdmop/templates/elastic.fleet.yaml
@@ -44,10 +44,6 @@ spec:
         automountServiceAccountToken: true
         securityContext:
           runAsUser: 0
-        tolerations:
-        - key: dedicated
-          effect: "NoSchedule"
-          operator: Exists
 ---
 
 {{ if .Values.elastic.fleetapm.enabled }}


### PR DESCRIPTION
- fleet-server-agent pods are running on data nodes causing SystemNodeSaturation.
- I have removed the toleration to resolve this issue.