### PR TITLE
Add Gateway API support for elastic stack ingress

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.3.3"
+version: "6.4.0"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.apm.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.apm.gateway-api.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.elastic.fleetapm.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: {{ .Release.Name }}-apm-backend-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Release.Name }}-apm-http
+  validation:
+    caCertificateRefs:
+      - name: {{ .Release.Name }}-es-http-ca-internal
+        group: ""
+        kind: Secret
+    hostname: {{ .Release.Name }}-apm-http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-apm
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: apm
+spec:
+  parentRefs:
+    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+  hostnames:
+    - {{ .Values.elastic.fleetapm.ingress.url }}
+  rules:
+    - backendRefs:
+        - name: {{ .Release.Name }}-apm-http
+          port: 8200
+{{- end }}

--- a/charts/lsdmop/templates/elastic.apm.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.apm.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{ if .Values.elastic.fleetapm.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -28,4 +29,5 @@ spec:
                 port:
                   number: 8200
 
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.entsearch.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.entsearch.gateway-api.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.elastic.enterprise_search.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: {{ .Release.Name }}-ent-backend-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: enterprise-search-{{ .Release.Name }}-ent-http
+  validation:
+    caCertificateRefs:
+      - name: {{ .Release.Name }}-ent-http-ca-internal
+        group: ""
+        kind: Secret
+    hostname: enterprise-search-{{ .Release.Name }}-ent-http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-entsearch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: enterprise-search
+spec:
+  parentRefs:
+    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+  hostnames:
+    - {{ .Values.elastic.enterprise_search.ingress.url }}
+  rules:
+    - backendRefs:
+        - name: enterprise-search-{{ .Release.Name }}-ent-http
+          port: 3002
+{{- end }}

--- a/charts/lsdmop/templates/elastic.entsearch.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.entsearch.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{- if .Values.elastic.enterprise_search.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -25,4 +26,5 @@ spec:
                 name: enterprise-search-{{ .Release.Name }}-ent-http
                 port:
                   number: 3002
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.es.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.es.gateway-api.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.elastic.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: {{ .Release.Name }}-es-backend-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Release.Name }}-elasticsearch-ingress
+  validation:
+    caCertificateRefs:
+      - name: {{ .Release.Name }}-es-http-ca-internal
+        group: ""
+        kind: Secret
+    hostname: {{ .Release.Name }}-elasticsearch-ingress
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-elasticsearch
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: elasticsearch
+spec:
+  parentRefs:
+    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+  hostnames:
+    - {{ .Values.elastic.ingress.url }}
+  rules:
+    - backendRefs:
+        - name: {{ .Release.Name }}-elasticsearch-ingress
+          port: 9200
+{{- end }}

--- a/charts/lsdmop/templates/elastic.es.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.es.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{- if .Values.elastic.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -29,4 +30,5 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.fleet.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.fleet.gateway-api.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.elastic.fleet.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: fleet-server-{{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fleet
+spec:
+  parentRefs:
+    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+  hostnames:
+    - {{ .Values.elastic.fleet.ingress.url }}
+  rules:
+    - backendRefs:
+        - name: fleet-server-lsdmop-agent-http
+          port: 8220
+{{- end }}

--- a/charts/lsdmop/templates/elastic.fleet.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.fleet.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{- if .Values.elastic.fleet.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -29,4 +30,5 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.kibana.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.kibana.gateway-api.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.elastic.kibana.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1alpha3
+kind: BackendTLSPolicy
+metadata:
+  name: {{ .Release.Name }}-kb-backend-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: {{ .Release.Name }}-kb-http
+  validation:
+    caCertificateRefs:
+      - name: {{ .Release.Name }}-kb-http-ca-internal
+        group: ""
+        kind: Secret
+    hostname: {{ .Release.Name }}-kb-http
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-kb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: kibana
+spec:
+  parentRefs:
+    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+  hostnames:
+    - {{ .Values.elastic.kibana.ingress.url }}
+  rules:
+    - backendRefs:
+        - name: {{ .Release.Name }}-kb-http
+          port: 5601
+{{- end }}

--- a/charts/lsdmop/templates/elastic.kibana.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.kibana.ingress.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{- if .Values.elastic.kibana.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -29,4 +30,5 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/values.yaml
+++ b/charts/lsdmop/values.yaml
@@ -11,11 +11,16 @@ elastic:
     enabled: false
   version: "9.3.1" #overridden upstream by Terraform
   ingress:
+    enabled: true
     annotations: {}
     className: "nginx"
     tls:
       secretName: elastic-ingress-tls
     url: "es-lsdmop"
+    gatewayAPI:
+      enabled: false       # when true, creates HTTPRoute + BackendTLSPolicy instead of Ingress
+      gatewayName: ""      # name of the Gateway to attach HTTPRoutes to
+      gatewayNamespace: "" # namespace of the Gateway (defaults to release namespace)
   dedicatedCoordinatingNodes: false
   serviceAccount:
     annotations: {}


### PR DESCRIPTION
## What

Adds Kubernetes Gateway API resource templates (HTTPRoute + BackendTLSPolicy) as an alternative to the existing Ingress resources for all elastic stack services.

## Why

We're migrating from nginx-ingress to Traefik. The elastic stack services use HTTPS backends with self-signed certificates (managed by ECK). With standard Ingress resources, there's no controller-agnostic way to configure backend TLS verification — nginx uses `backend-protocol: HTTPS` annotations, Traefik uses IngressRoute CRDs with ServersTransport. Neither approach is portable.

Gateway API solves this properly with `BackendTLSPolicy`, which:
- Is a Kubernetes standard (not controller-specific)
- Works with Traefik, NGINX Gateway Fabric, Envoy Gateway, and others
- References the ECK CA certificate secrets directly for proper TLS verification (no `insecureSkipVerify` hacks)
- Separates routing concerns (HTTPRoute) from backend TLS config (BackendTLSPolicy)

## How it works

New value `elastic.ingress.gatewayAPI.enabled` (default: `false`):
- When `false`: existing Ingress resources render as before (no change)
- When `true`: Ingress resources are suppressed, HTTPRoute + BackendTLSPolicy render instead

Configuration:
```yaml
elastic:
  ingress:
    gatewayAPI:
      enabled: true
      gatewayName: traefik-nginx-private    # Gateway to attach routes to
      gatewayNamespace: cluster-system       # Where the Gateway lives
```

## Services covered

| Service | HTTPRoute | BackendTLSPolicy | Notes |
|---------|-----------|------------------|-------|
| Elasticsearch | ✅ | ✅ | CA: `*-es-http-ca-internal` |
| Kibana | ✅ | ✅ | CA: `*-kb-http-ca-internal` |
| APM | ✅ | ✅ | CA: `*-es-http-ca-internal` |
| Fleet | ✅ | ❌ | HTTP backend, no TLS needed |
| Enterprise Search | ✅ | ✅ | CA: `*-ent-http-ca-internal` |

## Requirements

- Gateway API CRDs v1.4.0+ installed on the cluster
- A Gateway resource deployed (referenced by `gatewayName`/`gatewayNamespace`)
- Gateway controller that supports BackendTLSPolicy (e.g. Traefik v3.6+)

## Backward compatibility

No changes when `gatewayAPI.enabled` is false (the default). Existing deployments are unaffected.