### PR TITLE
Fix fleet output throughput values structure

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.4.0"
+version: "6.4.1"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/values.yaml
+++ b/charts/lsdmop/values.yaml
@@ -159,7 +159,9 @@ elastic:
   ## Fleet agents as a Daemonset to collect metrics/logs from Nodes (replaces metricbeat and filebeat)
   fleet:
     enabled: true
-    output.throughput.enabled: false
+    output:
+      throughput:
+        enabled: false
     fleetURL: "fleet-lsdmop"
     ingress:
       className: nginx


### PR DESCRIPTION
Fixes nil pointer error in `elastic.kibana.yaml` template at line 21.

The template accesses `.Values.elastic.fleet.output.throughput.enabled` as nested objects but `values.yaml` defined it as a flat dotted key (`output.throughput.enabled`). This causes a deployment failure on any chart version >= 6.3.3.

Introduced in d453d79 by @markbillett. Bumps chart to 6.4.1.