### PR TITLE
Fix BackendTLSPolicy apiVersion to v1

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.4.1"
+version: "6.4.2"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.apm.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.apm.gateway-api.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.elastic.fleetapm.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: {{ .Release.Name }}-apm-backend-tls

--- a/charts/lsdmop/templates/elastic.entsearch.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.entsearch.gateway-api.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.elastic.enterprise_search.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: {{ .Release.Name }}-ent-backend-tls

--- a/charts/lsdmop/templates/elastic.es.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.es.gateway-api.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.elastic.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: {{ .Release.Name }}-es-backend-tls

--- a/charts/lsdmop/templates/elastic.kibana.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.kibana.gateway-api.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.elastic.kibana.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
 ---
-apiVersion: gateway.networking.k8s.io/v1alpha3
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: {{ .Release.Name }}-kb-backend-tls


### PR DESCRIPTION
Gateway API v1.4.0 graduated BackendTLSPolicy to `v1` and stopped serving `v1alpha3`. The gateway-api templates were using the old version, causing deployment failures:

```
no matches for kind "BackendTLSPolicy" in version "gateway.networking.k8s.io/v1alpha3"
```

Updates all BackendTLSPolicy resources to use `gateway.networking.k8s.io/v1`. Bumps chart to 6.4.2.