### PR TITLE
Use ConfigMaps for BackendTLSPolicy CA certificate refs

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.4.2"
+version: "6.4.3"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.apm.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.apm.gateway-api.yaml
@@ -12,9 +12,9 @@ spec:
       name: {{ .Release.Name }}-apm-http
   validation:
     caCertificateRefs:
-      - name: {{ .Release.Name }}-es-http-ca-internal
+      - name: {{ .Release.Name }}-es-ca
         group: ""
-        kind: Secret
+        kind: ConfigMap
     hostname: {{ .Release.Name }}-apm-http
 ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/lsdmop/templates/elastic.ca-configmaps.yaml
+++ b/charts/lsdmop/templates/elastic.ca-configmaps.yaml
@@ -1,0 +1,58 @@
+{{/*
+  CA Certificate ConfigMaps for Gateway API BackendTLSPolicy.
+
+  ECK stores CA certificates in Secrets (tls.crt key), but Traefik's
+  BackendTLSPolicy implementation only supports caCertificateRefs
+  pointing to ConfigMaps. These ConfigMaps mirror the CA cert data
+  from the ECK-managed Secrets so that BackendTLSPolicy can reference them.
+
+  See: https://doc.traefik.io/traefik/v3.6/reference/install-configuration/providers/kubernetes/kubernetes-gateway
+*/}}
+{{- if and .Values.elastic.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
+{{- $esSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-es-http-ca-internal" .Release.Name)) }}
+{{- if $esSecret }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-es-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  ca.crt: |
+{{ index $esSecret.data "tls.crt" | b64dec | indent 4 }}
+{{- end }}
+{{- if .Values.elastic.kibana.enabled }}
+{{- $kbSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-kb-http-ca-internal" .Release.Name)) }}
+{{- if $kbSecret }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-kb-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  ca.crt: |
+{{ index $kbSecret.data "tls.crt" | b64dec | indent 4 }}
+{{- end }}
+{{- end }}
+{{- if .Values.elastic.enterprise_search.enabled }}
+{{- $entSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-ent-http-ca-internal" .Release.Name)) }}
+{{- if $entSecret }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ent-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  ca.crt: |
+{{ index $entSecret.data "tls.crt" | b64dec | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/lsdmop/templates/elastic.entsearch.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.entsearch.gateway-api.yaml
@@ -12,9 +12,9 @@ spec:
       name: enterprise-search-{{ .Release.Name }}-ent-http
   validation:
     caCertificateRefs:
-      - name: {{ .Release.Name }}-ent-http-ca-internal
+      - name: {{ .Release.Name }}-ent-ca
         group: ""
-        kind: Secret
+        kind: ConfigMap
     hostname: enterprise-search-{{ .Release.Name }}-ent-http
 ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/lsdmop/templates/elastic.es.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.es.gateway-api.yaml
@@ -12,9 +12,9 @@ spec:
       name: {{ .Release.Name }}-elasticsearch-ingress
   validation:
     caCertificateRefs:
-      - name: {{ .Release.Name }}-es-http-ca-internal
+      - name: {{ .Release.Name }}-es-ca
         group: ""
-        kind: Secret
+        kind: ConfigMap
     hostname: {{ .Release.Name }}-elasticsearch-ingress
 ---
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/lsdmop/templates/elastic.kibana.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.kibana.gateway-api.yaml
@@ -12,9 +12,9 @@ spec:
       name: {{ .Release.Name }}-kb-http
   validation:
     caCertificateRefs:
-      - name: {{ .Release.Name }}-kb-http-ca-internal
+      - name: {{ .Release.Name }}-kb-ca
         group: ""
-        kind: Secret
+        kind: ConfigMap
     hostname: {{ .Release.Name }}-kb-http
 ---
 apiVersion: gateway.networking.k8s.io/v1


### PR DESCRIPTION
Traefik's BackendTLSPolicy implementation only supports `caCertificateRefs` pointing to ConfigMaps, not Secrets. ECK stores CA certs in Secrets.

Adds a template that looks up ECK CA Secrets at deploy time and creates ConfigMaps mirroring the CA cert data. Updates all BackendTLSPolicy resources to reference these ConfigMaps.

Bumps chart to 6.4.3.