### PR TITLE
Fix BackendTLSPolicy hostnames and fleet service templating

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.4.3"
+version: "6.4.4"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.es.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.es.gateway-api.yaml
@@ -15,7 +15,7 @@ spec:
       - name: {{ .Release.Name }}-es-ca
         group: ""
         kind: ConfigMap
-    hostname: {{ .Release.Name }}-elasticsearch-ingress
+    hostname: {{ .Release.Name }}-es-http
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/lsdmop/templates/elastic.fleet.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.fleet.gateway-api.yaml
@@ -15,6 +15,6 @@ spec:
     - {{ .Values.elastic.fleet.ingress.url }}
   rules:
     - backendRefs:
-        - name: fleet-server-lsdmop-agent-http
+        - name: fleet-server-{{ .Release.Name }}-agent-http
           port: 8220
 {{- end }}


### PR DESCRIPTION
Fixes two issues preventing HTTPRoutes from working with BackendTLSPolicy:

1. **ES hostname mismatch**: BackendTLSPolicy `hostname` was set to `lsdmop-elasticsearch-ingress` but the ECK cert SAN only contains `lsdmop-es-http`. This caused TLS hostname verification to fail (500 errors). Fixed to use `{{ .Release.Name }}-es-http`.

2. **Fleet service hardcoded**: The fleet HTTPRoute had a hardcoded service name `fleet-server-lsdmop-agent-http` instead of using `{{ .Release.Name }}` templating.

Also includes the CA ConfigMaps template needed for Traefik's BackendTLSPolicy implementation (only supports ConfigMap refs for CA certs, not Secrets).

Bumps chart to 6.4.4.