### PR TITLE
Keep Ingress resources alongside HTTPRoutes, add fleet TLS

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.4.4"
+version: "6.4.5"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.apm.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.apm.ingress.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{ if .Values.elastic.fleetapm.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -29,5 +28,4 @@ spec:
                 port:
                   number: 8200
 
-{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.ca-configmaps.yaml
+++ b/charts/lsdmop/templates/elastic.ca-configmaps.yaml
@@ -55,4 +55,20 @@ data:
 {{ index $entSecret.data "tls.crt" | b64dec | indent 4 }}
 {{- end }}
 {{- end }}
+{{- if .Values.elastic.fleet.enabled }}
+{{- $fleetSecret := (lookup "v1" "Secret" .Release.Namespace (printf "fleet-server-%s-agent-http-ca-internal" .Release.Name)) }}
+{{- if $fleetSecret }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-fleet-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  ca.crt: |
+{{ index $fleetSecret.data "tls.crt" | b64dec | indent 4 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.entsearch.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.entsearch.ingress.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{- if .Values.elastic.enterprise_search.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -26,5 +25,4 @@ spec:
                 name: enterprise-search-{{ .Release.Name }}-ent-http
                 port:
                   number: 3002
-{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.es.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.es.ingress.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{- if .Values.elastic.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -30,5 +29,4 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
-{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.fleet.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.fleet.gateway-api.yaml
@@ -1,6 +1,23 @@
 {{- if and .Values.elastic.fleet.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: {{ .Release.Name }}-fleet-backend-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: fleet-server-{{ .Release.Name }}-agent-http
+  validation:
+    caCertificateRefs:
+      - name: {{ .Release.Name }}-fleet-ca
+        group: ""
+        kind: ConfigMap
+    hostname: fleet-server-{{ .Release.Name }}-agent-http
+---
+apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: fleet-server-{{ .Release.Name }}

--- a/charts/lsdmop/templates/elastic.fleet.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.fleet.ingress.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{- if .Values.elastic.fleet.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -30,5 +29,4 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
-{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.kibana.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.kibana.ingress.yaml
@@ -1,4 +1,3 @@
-{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 {{- if .Values.elastic.kibana.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -30,5 +29,4 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
-{{- end }}
 {{- end }}


### PR DESCRIPTION
Two fixes:

1. **Keep Ingress resources**: ExternalDNS only watches Ingress resources for DNS record creation. Suppressing them when gatewayAPI is enabled broke DNS resolution for all services. Now both Ingress and HTTPRoute coexist — HTTPRoute takes routing precedence, Ingress keeps DNS working.

2. **Add fleet BackendTLSPolicy**: Fleet uses HTTPS (port named `https`, cert has SANs). Was incorrectly assumed to be HTTP. Adds BackendTLSPolicy + CA ConfigMap for fleet.

Bumps chart to 6.4.5.