### PR TITLE
Multi-gateway support, suppress Ingress, add ReferenceGrant

### DIFF
--- a/charts/lsdmop/Chart.yaml
+++ b/charts/lsdmop/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: lsdmop
-version: "6.4.5"
+version: "6.5.0"
 appVersion: "1.0.2"
 # Disabling kubeVersion because GKE is dumb
 # kubeVersion: ">=v1.11.0"

--- a/charts/lsdmop/templates/elastic.apm.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.apm.gateway-api.yaml
@@ -26,8 +26,8 @@ metadata:
     app: apm
 spec:
   parentRefs:
-    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
-      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+    - name: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.name }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.namespace | default .Release.Namespace }}
   hostnames:
     - {{ .Values.elastic.fleetapm.ingress.url }}
   rules:

--- a/charts/lsdmop/templates/elastic.apm.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.apm.ingress.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.elastic.fleetapm.enabled }}
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,4 +29,5 @@ spec:
                 port:
                   number: 8200
 
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.entsearch.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.entsearch.gateway-api.yaml
@@ -26,8 +26,8 @@ metadata:
     app: enterprise-search
 spec:
   parentRefs:
-    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
-      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+    - name: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.name }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.namespace | default .Release.Namespace }}
   hostnames:
     - {{ .Values.elastic.enterprise_search.ingress.url }}
   rules:

--- a/charts/lsdmop/templates/elastic.entsearch.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.entsearch.ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.elastic.enterprise_search.enabled -}}
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -25,4 +26,5 @@ spec:
                 name: enterprise-search-{{ .Release.Name }}-ent-http
                 port:
                   number: 3002
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.es.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.es.gateway-api.yaml
@@ -26,12 +26,32 @@ metadata:
     app: elasticsearch
 spec:
   parentRefs:
-    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
-      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+    - name: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.name }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.namespace | default .Release.Namespace }}
   hostnames:
     - {{ .Values.elastic.ingress.url }}
   rules:
     - backendRefs:
         - name: {{ .Release.Name }}-elasticsearch-ingress
           port: 9200
+{{- if .Values.elastic.ingress.gatewayAPI.publicGateway.name }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-elasticsearch-public
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: elasticsearch
+spec:
+  parentRefs:
+    - name: {{ .Values.elastic.ingress.gatewayAPI.publicGateway.name }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.publicGateway.namespace | default .Release.Namespace }}
+  hostnames:
+    - {{ .Values.elastic.ingress.publicUrl | default (printf "elastic-public.%s" .Values.elastic.ingress.url) }}
+  rules:
+    - backendRefs:
+        - name: {{ .Release.Name }}-elasticsearch-ingress
+          port: 9200
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.es.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.es.ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.elastic.enabled -}}
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,4 +30,5 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.fleet.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.fleet.gateway-api.yaml
@@ -26,8 +26,8 @@ metadata:
     app: fleet
 spec:
   parentRefs:
-    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
-      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+    - name: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.name }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.namespace | default .Release.Namespace }}
   hostnames:
     - {{ .Values.elastic.fleet.ingress.url }}
   rules:

--- a/charts/lsdmop/templates/elastic.fleet.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.fleet.ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.elastic.fleet.enabled -}}
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,4 +30,5 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.kibana.gateway-api.yaml
+++ b/charts/lsdmop/templates/elastic.kibana.gateway-api.yaml
@@ -26,8 +26,8 @@ metadata:
     app: kibana
 spec:
   parentRefs:
-    - name: {{ .Values.elastic.ingress.gatewayAPI.gatewayName }}
-      namespace: {{ .Values.elastic.ingress.gatewayAPI.gatewayNamespace | default .Release.Namespace }}
+    - name: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.name }}
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.namespace | default .Release.Namespace }}
   hostnames:
     - {{ .Values.elastic.kibana.ingress.url }}
   rules:

--- a/charts/lsdmop/templates/elastic.kibana.ingress.yaml
+++ b/charts/lsdmop/templates/elastic.kibana.ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.elastic.kibana.enabled -}}
+{{- if not .Values.elastic.ingress.gatewayAPI.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -29,4 +30,5 @@ spec:
         path: /
         pathType: ImplementationSpecific
 ---
+{{- end }}
 {{- end }}

--- a/charts/lsdmop/templates/elastic.referencegrant.yaml
+++ b/charts/lsdmop/templates/elastic.referencegrant.yaml
@@ -1,0 +1,24 @@
+{{/*
+  ReferenceGrant allows the Gateway in another namespace to reference
+  TLS Secrets in this namespace for HTTPS listener termination.
+*/}}
+{{- if and .Values.elastic.enabled .Values.elastic.ingress.gatewayAPI.enabled }}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-gateway-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.privateGateway.namespace | default .Release.Namespace }}
+{{- if and .Values.elastic.ingress.gatewayAPI.publicGateway.name (ne .Values.elastic.ingress.gatewayAPI.publicGateway.namespace .Values.elastic.ingress.gatewayAPI.privateGateway.namespace) }}
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: {{ .Values.elastic.ingress.gatewayAPI.publicGateway.namespace }}
+{{- end }}
+  to:
+    - group: ""
+      kind: Secret
+{{- end }}

--- a/charts/lsdmop/values.yaml
+++ b/charts/lsdmop/values.yaml
@@ -17,10 +17,15 @@ elastic:
     tls:
       secretName: elastic-ingress-tls
     url: "es-lsdmop"
+    publicUrl: ""
     gatewayAPI:
-      enabled: false       # when true, creates HTTPRoute + BackendTLSPolicy instead of Ingress
-      gatewayName: ""      # name of the Gateway to attach HTTPRoutes to
-      gatewayNamespace: "" # namespace of the Gateway (defaults to release namespace)
+      enabled: false
+      privateGateway:
+        name: ""
+        namespace: ""
+      publicGateway:
+        name: ""
+        namespace: ""
   dedicatedCoordinatingNodes: false
   serviceAccount:
     annotations: {}


### PR DESCRIPTION
Chart 6.5.0 — consolidates the remaining Gateway API work:

- **Multi-gateway**: `gatewayAPI.privateGateway` and `gatewayAPI.publicGateway` replace the single `gatewayName`/`gatewayNamespace`. Public ES HTTPRoute created when `publicGateway.name` is set.
- **Suppress Ingress**: Ingress resources no longer rendered when `gatewayAPI.enabled: true`. ExternalDNS now creates DNS records from HTTPRoutes directly (via `gateway-httproute` source).
- **ReferenceGrant**: Allows the Gateway in cluster-system to reference TLS secrets in the lsdmop namespace for HTTPS listener termination.
- **publicUrl**: New field for the public Elasticsearch URL.